### PR TITLE
MIP21: fix remediation period bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all            :; dapp --use solc:0.5.12 build
 clean          :; dapp clean
-test           :; ./test-rwaspell.sh
+test           :; ./test-rwaspell.sh ${match}
 deploy         :; echo "use deploy-kovan or deploy-mainnet"
 deploy-kovan   :; ./scripts/deploy.sh kovan
 deploy-mainnet :; ./scripts/deploy.sh ethlive

--- a/src/RwaLiquidationOracle.sol
+++ b/src/RwaLiquidationOracle.sol
@@ -112,7 +112,7 @@ contract RwaLiquidationOracle {
     // --- write-off ---
     function cull(bytes32 ilk, address urn) external auth {
         require(ilks[ilk].pip != address(0));
-        require(add(ilks[ilk].toc, ilks[ilk].tau) >= block.timestamp);
+        require(add(ilks[ilk].toc, ilks[ilk].tau) <= block.timestamp);
 
         DSValue(ilks[ilk].pip).poke(bytes32(uint256(0)));
 
@@ -133,6 +133,7 @@ contract RwaLiquidationOracle {
     // to be called by off-chain parties (e.g. a trustee) to check the standing of the loan
     function good(bytes32 ilk) external view returns (bool) {
         require(ilks[ilk].pip != address(0));
-        return (ilks[ilk].toc == 0 || add(ilks[ilk].toc, ilks[ilk].tau) < block.timestamp);
+        // tell not called or still in remediation period
+        return (ilks[ilk].toc == 0 || add(ilks[ilk].toc, ilks[ilk].tau) > block.timestamp);
     }
 }

--- a/src/RwaLiquidationOracle.sol
+++ b/src/RwaLiquidationOracle.sol
@@ -77,7 +77,7 @@ contract RwaLiquidationOracle {
 
     function init(bytes32 ilk, uint256 val, string calldata doc, uint48 tau) external auth {
         // doc, and tau can be amended, but tau cannot decrease
-        require(tau >= ilks[ilk].tau);
+        require(tau >= ilks[ilk].tau, "RwaLiquidationOracle/decreasing-tau");
         ilks[ilk].doc = doc;
         ilks[ilk].tau = tau;
         if (ilks[ilk].pip == address(0)) {
@@ -92,15 +92,15 @@ contract RwaLiquidationOracle {
     function bump(bytes32 ilk, uint256 val) external auth {
         DSValue pip = DSValue(ilks[ilk].pip);
         // only cull can decrease
-        require(val >= uint256(pip.read()));
+        require(val >= uint256(pip.read()), "RwaLiquidationOracle/decreasing-val");
         DSValue(ilks[ilk].pip).poke(bytes32(val));
     }
     // --- liquidation ---
     function tell(bytes32 ilk) external auth {
         (,,,uint256 line,) = vat.ilks(ilk);
         // DC must be set to zero first
-        require(line == 0);
-        require(ilks[ilk].pip != address(0));
+        require(line == 0, "RwaLiquidationOracle/nonzero-line");
+        require(ilks[ilk].pip != address(0), "RwaLiquidationOracle/unknown-ilk");
         ilks[ilk].toc = uint48(block.timestamp);
         emit Tell(ilk);
     }
@@ -111,8 +111,8 @@ contract RwaLiquidationOracle {
     }
     // --- write-off ---
     function cull(bytes32 ilk, address urn) external auth {
-        require(ilks[ilk].pip != address(0));
-        require(add(ilks[ilk].toc, ilks[ilk].tau) <= block.timestamp);
+        require(ilks[ilk].pip != address(0), "RwaLiquidationOracle/unknown-ilk");
+        require(add(ilks[ilk].toc, ilks[ilk].tau) <= block.timestamp, "RwaLiquidationOracle/early-cull");
 
         DSValue(ilks[ilk].pip).poke(bytes32(uint256(0)));
 
@@ -132,7 +132,7 @@ contract RwaLiquidationOracle {
     // --- liquidation check ---
     // to be called by off-chain parties (e.g. a trustee) to check the standing of the loan
     function good(bytes32 ilk) external view returns (bool) {
-        require(ilks[ilk].pip != address(0));
+        require(ilks[ilk].pip != address(0), "RwaLiquidationOracle/unknown-ilk");
         // tell not called or still in remediation period
         return (ilks[ilk].toc == 0 || add(ilks[ilk].toc, ilks[ilk].tau) > block.timestamp);
     }

--- a/src/RwaLiquidationOracle.sol
+++ b/src/RwaLiquidationOracle.sol
@@ -112,7 +112,7 @@ contract RwaLiquidationOracle {
     // --- write-off ---
     function cull(bytes32 ilk, address urn) external auth {
         require(ilks[ilk].pip != address(0), "RwaLiquidationOracle/unknown-ilk");
-        require(add(ilks[ilk].toc, ilks[ilk].tau) <= block.timestamp, "RwaLiquidationOracle/early-cull");
+        require(block.timestamp >= add(ilks[ilk].toc, ilks[ilk].tau), "RwaLiquidationOracle/early-cull");
 
         DSValue(ilks[ilk].pip).poke(bytes32(uint256(0)));
 
@@ -134,6 +134,6 @@ contract RwaLiquidationOracle {
     function good(bytes32 ilk) external view returns (bool) {
         require(ilks[ilk].pip != address(0), "RwaLiquidationOracle/unknown-ilk");
         // tell not called or still in remediation period
-        return (ilks[ilk].toc == 0 || add(ilks[ilk].toc, ilks[ilk].tau) > block.timestamp);
+        return (ilks[ilk].toc == 0 || block.timestamp < add(ilks[ilk].toc, ilks[ilk].tau));
     }
 }

--- a/src/test/RwaUrn.t.sol
+++ b/src/test/RwaUrn.t.sol
@@ -384,7 +384,7 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
         // still in remeditation period
         assertTrue(oracle.good("acme"));
 
-        hevm.warp(now + 1 weeks);
+        hevm.warp(now + 2 weeks);
 
         assertEq(vat.gem("acme", address(oracle)), 0);
         // remediation period has elapsed
@@ -446,7 +446,7 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
         assertTrue(! usr.can_draw(1 ether));
         assertTrue(! usr2.can_draw(1 ether));
 
-        hevm.warp(now + 2 weeks);
+        hevm.warp(now + 3 weeks);
 
         oracle.cull("acme", address(urn));
 

--- a/src/test/RwaUrn.t.sol
+++ b/src/test/RwaUrn.t.sol
@@ -381,10 +381,14 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
         assertTrue(! usr.can_draw(10 ether));
 
         hevm.warp(now + 1 weeks);
+        // still in remeditation period
+        assertTrue(oracle.good("acme"));
+
+        hevm.warp(now + 1 weeks);
 
         assertEq(vat.gem("acme", address(oracle)), 0);
+        // remediation period has elapsed
         assertTrue(! oracle.good("acme"));
-
         oracle.cull("acme", address(urn));
 
         assertTrue(! usr.can_draw(10 ether));
@@ -403,16 +407,16 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
         assertEq(spot, 0);
     }
 
-    function test_oracle_bad_loan_is_good_again() public {
+    function test_oracle_unremedied_loan_is_not_good() public {
         usr.lock(1 ether);
         usr.draw(200 ether);
 
         vat.file("acme", "line", 0);
         oracle.tell("acme");
-        assertTrue(! oracle.good("acme"));
+        assertTrue(oracle.good("acme"));
 
         hevm.warp(now + 3 weeks);
-        assertTrue(oracle.good("acme"));
+        assertTrue(! oracle.good("acme"));
     }
 
     function test_oracle_cull_two_urns() public {
@@ -441,6 +445,8 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
 
         assertTrue(! usr.can_draw(1 ether));
         assertTrue(! usr2.can_draw(1 ether));
+
+        hevm.warp(now + 2 weeks);
 
         oracle.cull("acme", address(urn));
 

--- a/src/test/RwaUrn.t.sol
+++ b/src/test/RwaUrn.t.sol
@@ -449,11 +449,8 @@ contract RwaExampleTest is DSTest, DSMath, TryPusher {
         hevm.warp(now + 3 weeks);
 
         oracle.cull("acme", address(urn));
-
         assertEq(vat.sin(address(vow)), rad(100 ether));
-
         oracle.cull("acme", address(urn2));
-
         assertEq(vat.sin(address(vow)), rad(200 ether));
     }
 

--- a/test-rwaspell.sh
+++ b/test-rwaspell.sh
@@ -10,4 +10,8 @@ dapp --use solc:0.5.12 build
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+if [[ -z "$1" ]]; then
+    LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+else
+    LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 3 --match "$1"
+fi


### PR DESCRIPTION
This PR fixes a bug in the remediation period checks. Also it includes some test improvements, two new tests, the renaming of `fbo` to `outputConduit` in `RwaUrn.sol`, the addition of some shortened revert strings in the oracle, and verbose test matching.